### PR TITLE
feat: support time encoder

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -229,8 +229,9 @@ func (logger *Logger) Fatalw(message string, fields ...zapcore.Field) {
 // NewLogger sets up a Logger object according to a series of options.
 func NewLogger(opts ...Option) (*Logger, error) {
 	var (
-		writer zapcore.WriteSyncer
-		enc    zapcore.Encoder
+		writer      zapcore.WriteSyncer
+		enc         zapcore.Encoder
+		timeEncoder func(t time.Time, enc zapcore.PrimitiveArrayEncoder)
 	)
 
 	o := &options{
@@ -272,6 +273,12 @@ func NewLogger(opts ...Option) (*Logger, error) {
 		}
 	}
 
+	if o.timeEncoder != nil {
+		timeEncoder = o.timeEncoder
+	} else {
+		timeEncoder = zapcore.RFC3339TimeEncoder
+	}
+
 	if writer == os.Stdout || writer == os.Stderr {
 		enc = zapcore.NewConsoleEncoder(zapcore.EncoderConfig{
 			MessageKey:     "message",
@@ -282,7 +289,7 @@ func NewLogger(opts ...Option) (*Logger, error) {
 			StacktraceKey:  "backtrace",
 			LineEnding:     zapcore.DefaultLineEnding,
 			EncodeLevel:    zapcore.LowercaseColorLevelEncoder,
-			EncodeTime:     o.timeEncoder,
+			EncodeTime:     timeEncoder,
 			EncodeDuration: zapcore.StringDurationEncoder,
 			EncodeCaller:   zapcore.ShortCallerEncoder,
 		})
@@ -296,7 +303,7 @@ func NewLogger(opts ...Option) (*Logger, error) {
 			StacktraceKey:  "backtrace",
 			LineEnding:     zapcore.DefaultLineEnding,
 			EncodeLevel:    zapcore.LowercaseLevelEncoder,
-			EncodeTime:     o.timeEncoder,
+			EncodeTime:     timeEncoder,
 			EncodeDuration: zapcore.StringDurationEncoder,
 			EncodeCaller:   zapcore.ShortCallerEncoder,
 		})

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -282,7 +282,7 @@ func NewLogger(opts ...Option) (*Logger, error) {
 			StacktraceKey:  "backtrace",
 			LineEnding:     zapcore.DefaultLineEnding,
 			EncodeLevel:    zapcore.LowercaseColorLevelEncoder,
-			EncodeTime:     getTimeEncoder(o, zapcore.RFC3339TimeEncoder),
+			EncodeTime:     o.timeEncoder,
 			EncodeDuration: zapcore.StringDurationEncoder,
 			EncodeCaller:   zapcore.ShortCallerEncoder,
 		})
@@ -296,7 +296,7 @@ func NewLogger(opts ...Option) (*Logger, error) {
 			StacktraceKey:  "backtrace",
 			LineEnding:     zapcore.DefaultLineEnding,
 			EncodeLevel:    zapcore.LowercaseLevelEncoder,
-			EncodeTime:     getTimeEncoder(o, zapcore.RFC3339NanoTimeEncoder),
+			EncodeTime:     o.timeEncoder,
 			EncodeDuration: zapcore.StringDurationEncoder,
 			EncodeCaller:   zapcore.ShortCallerEncoder,
 		})
@@ -304,14 +304,4 @@ func NewLogger(opts ...Option) (*Logger, error) {
 	logger.writer = writer
 	logger.core = zapcore.NewCore(enc, writer, level)
 	return logger, nil
-}
-
-func getTimeEncoder(o *options, defaultEncoder func(t time.Time, enc zapcore.PrimitiveArrayEncoder)) func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-	var timeEncoder func(t time.Time, enc zapcore.PrimitiveArrayEncoder)
-	if o.timeEncoder == nil {
-		timeEncoder = defaultEncoder
-	} else {
-		timeEncoder = o.timeEncoder
-	}
-	return timeEncoder
 }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -282,7 +282,7 @@ func NewLogger(opts ...Option) (*Logger, error) {
 			StacktraceKey:  "backtrace",
 			LineEnding:     zapcore.DefaultLineEnding,
 			EncodeLevel:    zapcore.LowercaseColorLevelEncoder,
-			EncodeTime:     zapcore.RFC3339TimeEncoder,
+			EncodeTime:     getTimeEncoder(o, zapcore.RFC3339TimeEncoder),
 			EncodeDuration: zapcore.StringDurationEncoder,
 			EncodeCaller:   zapcore.ShortCallerEncoder,
 		})
@@ -296,7 +296,7 @@ func NewLogger(opts ...Option) (*Logger, error) {
 			StacktraceKey:  "backtrace",
 			LineEnding:     zapcore.DefaultLineEnding,
 			EncodeLevel:    zapcore.LowercaseLevelEncoder,
-			EncodeTime:     zapcore.RFC3339NanoTimeEncoder,
+			EncodeTime:     getTimeEncoder(o, zapcore.RFC3339NanoTimeEncoder),
 			EncodeDuration: zapcore.StringDurationEncoder,
 			EncodeCaller:   zapcore.ShortCallerEncoder,
 		})
@@ -304,4 +304,14 @@ func NewLogger(opts ...Option) (*Logger, error) {
 	logger.writer = writer
 	logger.core = zapcore.NewCore(enc, writer, level)
 	return logger, nil
+}
+
+func getTimeEncoder(o *options, defaultEncoder func(t time.Time, enc zapcore.PrimitiveArrayEncoder)) func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+	var timeEncoder func(t time.Time, enc zapcore.PrimitiveArrayEncoder)
+	if o.timeEncoder == nil {
+		timeEncoder = defaultEncoder
+	} else {
+		timeEncoder = o.timeEncoder
+	}
+	return timeEncoder
 }

--- a/pkg/log/options.go
+++ b/pkg/log/options.go
@@ -15,6 +15,8 @@
 package log
 
 import (
+	"time"
+
 	"go.uber.org/zap/zapcore"
 )
 
@@ -37,6 +39,7 @@ type options struct {
 	logLevel    string
 	context     string
 	skipFrames  int
+	timeEncoder func(t time.Time, enc zapcore.PrimitiveArrayEncoder)
 }
 
 // WithLogLevel sets the log level.
@@ -83,6 +86,19 @@ func WithSkipFrames(sf int) Option {
 	return &funcOption{
 		do: func(o *options) {
 			o.skipFrames = sf
+		},
+	}
+}
+
+// WithTimeEncoder sets the time encoder
+func WithTimeEncoder(layout string) Option {
+	return &funcOption{
+		do: func(o *options) {
+			if layout == "" {
+				o.timeEncoder = nil
+				return
+			}
+			o.timeEncoder = zapcore.TimeEncoderOfLayout(layout)
 		},
 	}
 }

--- a/pkg/log/options.go
+++ b/pkg/log/options.go
@@ -95,10 +95,10 @@ func WithTimeEncoder(layout string) Option {
 	return &funcOption{
 		do: func(o *options) {
 			if layout == "" {
-				o.timeEncoder = nil
-				return
+				o.timeEncoder = zapcore.RFC3339TimeEncoder
+			} else {
+				o.timeEncoder = zapcore.TimeEncoderOfLayout(layout)
 			}
-			o.timeEncoder = zapcore.TimeEncoderOfLayout(layout)
 		},
 	}
 }


### PR DESCRIPTION
support custom time fotmat layout. example:
```go
logger, err := NewLogger(WithTimeEncoder("2006-01-02 15:04:00.000"))
```